### PR TITLE
Add basescan to network.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ apiName is one of:
  - cronoscan
  - moonbeam
  - aurora
+ - basescan
+ - goerli.basescan
 
  contractAddress in hexadecimal format (i.e 0x1F98431c8aD98523631AE4a59f267346ea31F984)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ethereum-sources-downloader",
-  "version": "0.1.5",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ethereum-sources-downloader",
-      "version": "0.1.5",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "commander": "^9.3.0",

--- a/src/explorer/networks.ts
+++ b/src/explorer/networks.ts
@@ -22,8 +22,10 @@ export const explorerApiUrls = {
   snowtrace: "https://api.snowtrace.io/api",
   "testnet.snowtrace": "https://api-testnet.snowtrace.io/api",
   cronoscan: "https://api.cronoscan.com/api",
-  moonbeam: 'https://api-moonbeam.moonscan.io/api',
-  aurora: 'https://api.aurorascan.dev/api'
+  moonbeam: "https://api-moonbeam.moonscan.io/api",
+  aurora: "https://api.aurorascan.dev/api",
+  basescan: "https://api.basescan.org/api",
+  "goerli.basescan": "https://api-goerli.basescan.org"
 };
 
 /**
@@ -55,8 +57,10 @@ export const networkNames: Record<ApiName, string> = {
   snowtrace: "avalanche",
   "testnet.snowtrace": "avalancheTestnet",
   cronoscan: "cronos",
-  moonbeam: 'moonbeam',
-  aurora: 'aurora'
+  moonbeam: "moonbeam",
+  aurora: "aurora",
+  basescan: "basescan",
+  "goerli.basescan": "basescanGoerli"
 };
 
 const ETHERSCAN_KEY = "862Y3WJ4JB4B34PZQRFEV3IK6SZ8GNR9N5";
@@ -69,6 +73,7 @@ const POLYGONSCAN_KEY = "RV4YXDXEMIHXMC7ZXB8T82G4F56FRZ1SZQ";
 const CRONOSCAN_KEY = "BGAN1CWT8E1A2XRS3FU61UP7XXFMHBWNSY";
 const MOONBEAM_KEY = "FENPKQI49RF2P916SQ2J58BTDMU69PQY8Y";
 const AURORA_KEY = "F2JS84SQHM53V4T3AN2CSX6ZHUAXFSHJ8Y";
+const BASESCAN_KEY = "ICQQDUA1C8R2EZY6M4QIIV7WUEZM8INNA7";
 
 export const explorerApiKeys: Record<ApiName, string> = {
   etherscan: ETHERSCAN_KEY,
@@ -100,5 +105,8 @@ export const explorerApiKeys: Record<ApiName, string> = {
 
   cronoscan: CRONOSCAN_KEY,
   moonbeam: MOONBEAM_KEY,
-  aurora: AURORA_KEY
+  aurora: AURORA_KEY,
+
+  basescan: BASESCAN_KEY,
+  'goerli.basescan': BASESCAN_KEY
 };


### PR DESCRIPTION
DethCode recently added Basescan.org support in [this PR](https://github.com/dethcrypto/dethcode/pull/82).

## What changed?

- Update `package-lock.json` by running `npm install`
- Add Basescan to `network.ts`
  - Add `goerli.basescan` too
- Update `README.md` to reflect these changes

## How was this tested?

- Ran `node dist/index.js` locally with the following command:
  - `node dist/index.js basescan 0x4fcd0f6bfc24a13bfc64509912dad699d26e4f7a`
  - Gave successful output

![image](https://github.com/SergeKireev/ethereum-sources-downloader/assets/8400251/3163569f-1a38-416f-8239-a27e511f429a)
