### PR TITLE
fix: finding supported chain Ids for Etherscan V2 API

### DIFF
--- a/src/io/cli/commandLine.ts
+++ b/src/io/cli/commandLine.ts
@@ -17,7 +17,7 @@ function validateSupportedNetworkV2(_networkId: string): void {
   } catch (e) {
     throw new Error(`In Etherscan V2 API, Network id should be the chain id`)
   }
-  const found = Object.keys(v2SupportedNetworks).find((_, supportedNetworkId: number) => supportedNetworkId === networkId)
+  const found = explorer_1.v2SupportedNetworks.hasOwnProperty(String(networkId)) ? String(networkId) : undefined;
   if (!found) {
     throw new Error(`Network id ${_networkId} is not supported, supported network ids are ${Object.keys(v2SupportedNetworks)}`);
   }


### PR DESCRIPTION
Please consider updating the code following the PR and re-releasing it. For now the `find()` function does not fetch the result correctly, so only several networks work by accident as a result.

These are the logs leading to error finding:
```
node_modules/ethereum-sources-downloader/dist/index.js 137 0xE3607b00E75f6405248323A9417ff6b39B244b50 out2 -a v2 -k $ETHERSCAN_API_KEY
{"apiVersion":"v2","apiKey":"###"}
!!!!!NETWORK ID 137
FOUND 137
node_modules/ethereum-sources-downloader/dist/io/cli/commandLine.js:31
        throw new Error(`Network id ${_networkId} is not supported, supported network ids are ${Object.keys(explorer_1.v2SupportedNetworks)}`);
        ^

Error: Network id 137 is not supported, supported network ids are 1,10,25,50,51,56,97,100,130,137,146,199,252,300,324,480,1028,1101,1111,1112,1284,1285,1287,1301,1923,1924,2442,2522,2741,4352,4801,5000,5003,8453,11124,17000,33111,33139,42161,42170,42220,43113,43114,43521,44787,50104,57054,59141,59144,80002,80069,80094,81457,84532,167000,167009,421614,534351,534352,660279,11155111,11155420,168587773,531050104,37714555429
```

The chain Id is passed correctly and is in the list of supported chain Ids, however it is not picked up correctly by the `find()` command.

Thank you for your hard work!!